### PR TITLE
Add autoload comment for `org-block-capf`

### DIFF
--- a/org-block-capf.el
+++ b/org-block-capf.el
@@ -56,6 +56,7 @@ Otherwise, insert block at cursor position."
 
 (defvar org-block-capf--regexp "\\(<\\)\\([^ ]*\\)")
 
+;;;###autoload
 (defun org-block-capf ()
   "Function used for `completion-at-point-functions'."
   (when-let* ((activated (looking-back (org-block-capf--regexp)


### PR DESCRIPTION
Thanks for making this that fast after I suggested it! I tested it and the basic completion and wrapping seems to work with default-completion, corfu, and with company and its company-capf backend. I lazy-load my packages, which is why I added a magic `;;;###autoload` comment in this PR.

##  Comments on the package unrelated to this PR

I think while this package is young and not officially distributed, I would think about naming. `capf` is just an abbreviation for `completion-at-point` and I use it because it's fast to type and minad uses it in his packages. But in emacs itself this abbreviation is never used and capfs usually end with `-completion-at-point`,  which is more self-explanatory than `-capf`. E.g. `elisp-completion-at-point`,  `python-completion-at-point`, `eglot-completion-at-point`. But `completion-at-point` is definetly longer to type and therefore I wouldn't use it as a package namespace. Since this is the default built-in completion in emacs I could also imagine just naming the package `org-block-completion`. But I also don't mind `org-block-capf`, I just wanted to make you aware that it's not the only choice and I might have biased you in that direction by using that abbreviation. Once you advertise this package more, changing the names will get more difficult, so better consider what's best now.