### PR TITLE
 Add annotations and preview with doc-buffer

### DIFF
--- a/org-block-capf.el
+++ b/org-block-capf.el
@@ -71,6 +71,8 @@ Otherwise, insert block at cursor position."
       (lambda (_)
         (org-block-capf--all-candidates)))
      :exclusive 'no
+     :annotation-function
+     (lambda (_) " <org-block>")
      :exit-function
      (lambda (insertion _status)
        (when (seq-contains-p (org-block-capf--all-candidates) insertion)

--- a/org-block-capf.el
+++ b/org-block-capf.el
@@ -125,8 +125,8 @@ Otherwise, insert block at cursor position."
 
 (defun org-block-capf--template-p (template)
   "Check if there is a TEMPLATE available for completion."
-  (seq-contains (map-values org-structure-template-alist)
-                template))
+  (seq-contains-p (map-values org-structure-template-alist)
+                  template))
 
 
 ;; adapted from company-org-block--company-buffer by Jen-Chieh

--- a/org-block-capf.el
+++ b/org-block-capf.el
@@ -73,6 +73,8 @@ Otherwise, insert block at cursor position."
      :exclusive 'no
      :annotation-function
      (lambda (_) " <org-block>")
+     :company-doc-buffer
+     #'org-block-capf--doc-buffer
      :exit-function
      (lambda (insertion _status)
        (when (seq-contains-p (org-block-capf--all-candidates) insertion)
@@ -125,6 +127,20 @@ Otherwise, insert block at cursor position."
   "Check if there is a TEMPLATE available for completion."
   (seq-contains (map-values org-structure-template-alist)
                 template))
+
+
+;; adapted from company-org-block--company-buffer by Jen-Chieh
+(defun org-block-capf--doc-buffer (candidate)
+  "Return documentation buffer for CANDIDATE."
+  (let ((candidate (if (string-equal "src" candidate)
+                       ""
+                     candidate))
+        (org-block-capf-edit-style 'inline))
+    (with-current-buffer (get-buffer-create " *org-block-capf doc*")
+      (erase-buffer)
+      (insert "<" candidate)
+      (org-block-capf--expand candidate nil)
+      (current-buffer))))
 
 (defun org-block-capf--expand (insertion query-lang)
   "Replace INSERTION with generated source block."


### PR DESCRIPTION
Adapted from the implementation of `company-org-block--company-buffer` by @jcs090218 in
https://github.com/xenodium/company-org-block/pull/14. Then main change is in not using the `company-doc-buffer` helper function to avoid a dependency on company.

Also added annotations but that was trivial and replaced on obsolete function.

Below is how it looks when enabling `corfu-popupinfo-mode`: 

![image](https://user-images.githubusercontent.com/5121824/213881016-96cf3d78-8441-45ed-befb-b14de2f7cbeb.png)

Haven't tested yet whether `company-mode` with `company-capf` correctly picks this up.

I think this mostly resolves #3. Not sure if there are any other remaining features in `company-org-block` that need to be added to `org-block-capf` via extra properties.