### PR TITLE
Hook for hook setup helper and improve readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,9 @@
 
 tl;dr “<” to trigger org block completion at point.
 
-[[file:corfu.png]]
+#+attr_html: :align center
+[[file:corfu.png]]\\
+Screenshot of =org-block-capf= completion in =corfu= with =corfu-popupinfo-mode= enabled for block preview.
 
 Like [[https://github.com/xenodium/company-org-block][company-org-block]], but for users of the built-in =completion-at-point= completion or its extensions like [[https://github.com/minad/corfu][corfu]], who want similar functionality without the [[https://company-mode.github.io/][company]] dependency. It's remains compatible with company via its =company-capf= backend.
 

--- a/README.org
+++ b/README.org
@@ -8,11 +8,10 @@ Like [[https://github.com/xenodium/company-org-block][company-org-block]], but f
 
 Check out [[https://github.com/xenodium/company-org-block][company-org-block]] to get a feel for the functionality and capabilities.
 
-You can enable =org-block-capf= by adding it to =completion-at-point-functions= or you can invoke =org-block-capf-add-to-completion-at-point-functions=
-as follows:
+To enable =org-block-capf=, add it to =completion-at-point-functions= (locally) in org-mode, which you can do via:
 
 #+begin_src emacs-lisp :lexical no
   (require 'org-block-capf)
 
-  (org-block-capf-add-to-completion-at-point-functions)
+  (add-hook 'org-mode-hook #'org-block-capf-add-to-completion-at-point-functions)
 #+end_src

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ tl;dr “<” to trigger org block completion at point.
 
 [[file:corfu.png]]
 
-Like [[https://github.com/xenodium/company-org-block][company-org-block]], but for =completion-at-point= users who'd like similar funcitonality without the [[https://company-mode.github.io/][company]] dependency.
+Like [[https://github.com/xenodium/company-org-block][company-org-block]], but for =completion-at-point= users who'd like similar functionality without the [[https://company-mode.github.io/][company]] dependency.
 
 Check out [[https://github.com/xenodium/company-org-block][company-org-block]] to get a feel for the functionality and capabilities.
 

--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@ tl;dr “<” to trigger org block completion at point.
 
 [[file:corfu.png]]
 
-Like [[https://github.com/xenodium/company-org-block][company-org-block]], but for =completion-at-point= users who'd like similar functionality without the [[https://company-mode.github.io/][company]] dependency.
+Like [[https://github.com/xenodium/company-org-block][company-org-block]], but for users of the built-in =completion-at-point= completion or its extensions like [[https://github.com/minad/corfu][corfu]], who want similar functionality without the [[https://company-mode.github.io/][company]] dependency. It's remains compatible with company via its =company-capf= backend.
 
 Check out [[https://github.com/xenodium/company-org-block][company-org-block]] to get a feel for the functionality and capabilities.
 

--- a/org-block-capf.el
+++ b/org-block-capf.el
@@ -81,6 +81,7 @@ Otherwise, insert block at cursor position."
        (when (seq-contains-p (org-block-capf--all-candidates) insertion)
          (org-block-capf--expand insertion t))))))
 
+;;;###autoload
 (defun org-block-capf-add-to-completion-at-point-functions ()
   "Add `org-block-capf' to `completion-at-point-functions'."
   (let ((capf #'org-block-capf))


### PR DESCRIPTION
# org-block-capf setup

The most important change is that the old setup recommendation
``` emacs-lisp
(org-block-capf-add-to-completion-at-point-functions)
```
doesn't work for me, because that function only adds the capf buffer-locally, so I actually need to hook the function to `org-mode` to get the new capf to work.

I thought whether it would work to just use the global
``` emacs-lisp
(add-to-list 'completion-at-point-functions #'org-block-capf)
```
The problem is that org-mode also appends to `completion-at-point-functions` buffer-locally in [org.el#L4892](https://git.sr.ht/~bzg/org-mode/tree/main/item/lisp/org.el#L4892):
``` emacs-lisp
  (add-hook 'completion-at-point-functions
            #'pcomplete-completions-at-point nil t)
```
I think this means that if adding `org-block-capf` to the global `completion-at-point functions` before org-mode is loaded, it will work to  because the local add-hook will just make to global capfs local and extend it capfs. However, if we load org-mode first and then add to the global capfs, then the block-completion in org will not work because it's already buffer-local and thus global changes will not affect it. This global hook of a local hook function is what works best for me, but not sure if other capf users would consider that best-practice :shrug: 

I changed the readme to recommend adding it locally and using and org-mode-hook. Also I made the setup function autoload, because I use use-package+straight and only lazily load org-block-capf. 

# Other README changes
While editing the readme I introduced other changes. Mentioned that completion-at-point is the builtin completion, mentioned and linked to corfu as an example extension, and noted that it's still compatible with company.

Also I added a caption to the image, first that people know which extra packages I used to achieve that result and secondly because we have no alt-text and for people with vision impairment one should have either that or a caption. I considered using the org-mode `#+CAPTION:` attribute, but it adds a `Figure 1: ...` in the emacs html export before the text and I don't want that, also I'm not sure how that would look in github, just an extra line in the same paragraph seemed simpler.