### PR TITLE
Make `org-block-capf` an interactive command

### DIFF
--- a/README.org
+++ b/README.org
@@ -8,11 +8,12 @@ Like [[https://github.com/xenodium/company-org-block][company-org-block]], but f
 
 Check out [[https://github.com/xenodium/company-org-block][company-org-block]] to get a feel for the functionality and capabilities.
 
-You can enable =org-block-capf= by adding it to =completion-at-point-functions= or you can invoke =org-block-capf-add-to-completion-at-point-functions=
-as follows:
-
+To enable =org-block-capf=, add it to the =completion-at-point-functions= in org-mode, which you can do via:
 #+begin_src emacs-lisp :lexical no
   (require 'org-block-capf)
 
   (org-block-capf-add-to-completion-at-point-functions)
 #+end_src
+Then, completing the “<” via =complete-symbol= / =completion-at-point= in org-mode should let you select an org block.
+
+Alternatively, you can use =M-x org-block-capf= as an interactive command to complete “<”, which doesn't require the above setup, as it uses itself as a completion-at-point-function.

--- a/org-block-capf.el
+++ b/org-block-capf.el
@@ -57,29 +57,35 @@ Otherwise, insert block at cursor position."
 (defvar org-block-capf--regexp "\\(<\\)\\([^ ]*\\)")
 
 ;;;###autoload
-(defun org-block-capf ()
-  "Function used for `completion-at-point-functions'."
-  (when-let* ((activated (looking-back (org-block-capf--regexp)
-                                       (line-beginning-position)))
-              (range (or (bounds-of-thing-at-point 'symbol)
-                         (cons (point) (point))))
-              (end (cdr range))
-              (start (car range)))
-    (list
-     start
-     end
-     (completion-table-dynamic
-      (lambda (_)
-        (org-block-capf--all-candidates)))
-     :exclusive 'no
-     :annotation-function
-     (lambda (_) " <org-block>")
-     :company-doc-buffer
-     #'org-block-capf--doc-buffer
-     :exit-function
-     (lambda (insertion _status)
-       (when (seq-contains-p (org-block-capf--all-candidates) insertion)
-         (org-block-capf--expand insertion t))))))
+(defun org-block-capf (&optional interactive)
+  "Complete `<' prefix to an org block.
+If INTERACTIVE is nil the function acts like a Capf that can be
+be added to `completion-at-point-functions'"
+  (interactive (list t))
+  (if interactive
+      (let ((completion-at-point-functions (list #'org-block-capf)))
+        (or (completion-at-point) (user-error "%s: No completions" #'org-block-capf)))
+    (when-let* ((activated (looking-back (org-block-capf--regexp)
+                                         (line-beginning-position)))
+                (range (or (bounds-of-thing-at-point 'symbol)
+                           (cons (point) (point))))
+                (end (cdr range))
+                (start (car range)))
+      (list
+       start
+       end
+       (completion-table-dynamic
+        (lambda (_)
+          (org-block-capf--all-candidates)))
+       :exclusive 'no
+       :annotation-function
+       (lambda (_) " <org-block>")
+       :company-doc-buffer
+       #'org-block-capf--doc-buffer
+       :exit-function
+       (lambda (insertion _status)
+         (when (seq-contains-p (org-block-capf--all-candidates) insertion)
+           (org-block-capf--expand insertion t)))))))
 
 (defun org-block-capf-add-to-completion-at-point-functions ()
   "Add `org-block-capf' to `completion-at-point-functions'."


### PR DESCRIPTION
`org-block-capf` acts still as a capf when called non-interactively, but when called interactively it uses itself as a capf to complete the symbol at point. This is inspired by how the `cape`-capfs work which all do that.

Not that the interactive version of the command still does normal completion, i.e. it only works when the cursor is after a `<`. It might be nice to have an interactive command that works anywhere in an org-mode buffer but that's something separate, it's not really a completion then but just a selection.